### PR TITLE
Synchronise last session with the remote.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,6 +12,7 @@ android {
         targetSdkVersion 30
         versionCode 1
         versionName "1.0"
+        buildConfigField "String", 'SERVER_URL', '"http://192.168.1.20:8081"'
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
@@ -26,6 +27,7 @@ android {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+            buildConfigField "String", 'SERVER_URL', '"http://192.168.1.20:8081"'
         }
     }
     compileOptions {
@@ -63,4 +65,6 @@ dependencies {
     implementation 'com.google.android.material:material:1.3.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
     implementation 'androidx.localbroadcastmanager:localbroadcastmanager:1.0.0'
+    implementation 'com.google.code.gson:gson:2.8.6'
+    implementation 'com.android.volley:volley:1.2.0'
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
     <uses-permission android:name="android.permission.BLUETOOTH" />
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
 
     <application
@@ -14,6 +15,7 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
+        android:usesCleartextTraffic="true"
         android:theme="@style/Theme.ExerciseAnalyst">
         <activity
             android:name=".activities.SessionTaggingActivity"

--- a/app/src/main/java/pl/ppiwd/exerciseanalyst/activities/utils/ServerConnection.java
+++ b/app/src/main/java/pl/ppiwd/exerciseanalyst/activities/utils/ServerConnection.java
@@ -1,0 +1,94 @@
+package pl.ppiwd.exerciseanalyst.activities.utils;
+
+import android.content.Context;
+import android.util.Log;
+import android.widget.Toast;
+
+import com.android.volley.Request;
+import com.android.volley.RequestQueue;
+import com.android.volley.VolleyError;
+import com.android.volley.toolbox.StringRequest;
+import com.android.volley.toolbox.Volley;
+import com.google.gson.Gson;
+
+import java.util.concurrent.CompletableFuture;
+
+import io.reactivex.rxjava3.core.Single;
+import io.reactivex.rxjava3.functions.Action;
+import io.reactivex.rxjava3.functions.Function;
+import pl.ppiwd.exerciseanalyst.BuildConfig;
+import pl.ppiwd.exerciseanalyst.persistence.MeasurementSelectCommand;
+import pl.ppiwd.exerciseanalyst.persistence.dao.MeasurementsDao;
+import pl.ppiwd.exerciseanalyst.persistence.entities.SessionWithMeasurements;
+import pl.ppiwd.exerciseanalyst.utils.Command;
+
+public class ServerConnection {
+    private MeasurementsDao measurementsDao;
+    private CompletableFuture currentRequest;
+    private Runnable onSuccess;
+    private Runnable onError;
+
+    public ServerConnection(MeasurementsDao dao
+            , Runnable onSuccess
+            , Runnable onError) {
+        this.measurementsDao = dao;
+        this.currentRequest = null;
+        this.onSuccess = onSuccess;
+        this.onError = onError;
+    }
+
+    public void sendMeasurements(Context context) {
+        if (currentRequest == null || currentRequest.isDone()) {
+            CompletableFuture dbQuery = new MeasurementSelectCommand(measurementsDao).execute();
+            sendRequest(dbQuery, context);
+        } else {
+            /**
+             * TODO:
+             * There's no particular reason behind not being able to query
+             * multiple requests. With the current context it's a bit pointless,
+             * as you're going to be sending the same data over and over
+             * (MeasurementSelectCommand always queries the last row).
+             */
+            Log.e("ServerConnection", "Request is already in progress.");
+        }
+    }
+
+    public void cancelRequest() {
+        if (currentRequest != null && !currentRequest.isDone()) {
+            currentRequest.cancel(true);
+        }
+    }
+
+    private void sendRequest(CompletableFuture callbackChain, Context context) {
+        this.currentRequest = callbackChain.thenApply(param -> {
+            Log.i("ServerConnection", "Querying local data.");
+            SessionWithMeasurements measurements = ((Single<SessionWithMeasurements>) param).blockingGet();
+            Log.i("ServerConnection", "Local data queried, serializing.");
+            Gson gson = new Gson();
+            String jsonStr = gson.toJson(measurements);
+
+            RequestQueue queue = Volley.newRequestQueue(context);
+            StringRequest stringRequest = new StringRequest(
+                    Request.Method.POST,
+                    BuildConfig.SERVER_URL,
+                    response -> {
+                        try { onSuccess.run(); } catch(Throwable e) { }
+                        Log.i("ServerConnection", "Received response: " + response.toString());
+                    },
+                    error -> {
+                        try { onError.run(); } catch(Throwable e) { }
+                        Log.e("ServerConnection", error.toString());
+                    }) {
+                @Override
+                public byte[] getBody() {
+                    return jsonStr.getBytes();
+                }
+            };
+
+            Log.i("ServerConnection",
+                    "Sending measurements to " + BuildConfig.SERVER_URL);
+            queue.add(stringRequest);
+            return null;
+        });
+    }
+}

--- a/app/src/main/java/pl/ppiwd/exerciseanalyst/activities/utils/ServerConnection.java
+++ b/app/src/main/java/pl/ppiwd/exerciseanalyst/activities/utils/ServerConnection.java
@@ -64,8 +64,8 @@ public class ServerConnection {
             Log.i("ServerConnection", "Querying local data.");
             SessionWithMeasurements measurements = ((Single<SessionWithMeasurements>) param).blockingGet();
             Log.i("ServerConnection", "Local data queried, serializing.");
-            Gson gson = new Gson();
-            String jsonStr = gson.toJson(measurements);
+            SessionSerializer serializer = new SessionSerializer(measurements);
+            String json = serializer.serialize();
 
             RequestQueue queue = Volley.newRequestQueue(context);
             StringRequest stringRequest = new StringRequest(
@@ -81,7 +81,7 @@ public class ServerConnection {
                     }) {
                 @Override
                 public byte[] getBody() {
-                    return jsonStr.getBytes();
+                    return json.getBytes();
                 }
             };
 

--- a/app/src/main/java/pl/ppiwd/exerciseanalyst/activities/utils/SessionSerializer.java
+++ b/app/src/main/java/pl/ppiwd/exerciseanalyst/activities/utils/SessionSerializer.java
@@ -1,0 +1,38 @@
+package pl.ppiwd.exerciseanalyst.activities.utils;
+
+import com.google.gson.ExclusionStrategy;
+import com.google.gson.FieldAttributes;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+import pl.ppiwd.exerciseanalyst.persistence.entities.SessionWithMeasurements;
+
+public class SessionSerializer {
+    private ExclusionStrategy excludedParams;
+    private SessionWithMeasurements sessionData;
+    private Gson gson;
+
+    public SessionSerializer(SessionWithMeasurements sessionData) {
+        this.sessionData = sessionData;
+        this.excludedParams = new ExclusionStrategy() {
+            @Override
+            public boolean shouldSkipField(FieldAttributes field) {
+                if (field.getDeclaringClass() != SessionWithMeasurements.class
+                        && (field.getName().equals("sessionId") || field.getName().equals("measurementId"))) {
+                    return true;
+                }
+                return false;
+            }
+
+            @Override
+            public boolean shouldSkipClass(Class<?> clazz) {
+                return false;
+            }
+        };
+        this.gson = new GsonBuilder().addSerializationExclusionStrategy(this.excludedParams).create();
+    }
+
+    public String serialize() {
+        return this.gson.toJson(this.sessionData);
+    }
+}

--- a/app/src/main/java/pl/ppiwd/exerciseanalyst/persistence/MeasurementSelectCommand.java
+++ b/app/src/main/java/pl/ppiwd/exerciseanalyst/persistence/MeasurementSelectCommand.java
@@ -1,0 +1,21 @@
+package pl.ppiwd.exerciseanalyst.persistence;
+
+import java.util.concurrent.CompletableFuture;
+
+import pl.ppiwd.exerciseanalyst.persistence.dao.MeasurementsDao;
+import pl.ppiwd.exerciseanalyst.utils.Command;
+
+public class MeasurementSelectCommand implements Command<CompletableFuture> {
+
+    private MeasurementsDao measurementsDao;
+
+    public MeasurementSelectCommand(MeasurementsDao measurements) {
+        this.measurementsDao = measurements;
+    }
+
+    @Override
+    public CompletableFuture execute() {
+        return CompletableFuture
+                .supplyAsync(() -> measurementsDao.getMeasurementEntitiesForLastSession());
+    }
+}

--- a/app/src/main/java/pl/ppiwd/exerciseanalyst/persistence/dao/MeasurementsDao.java
+++ b/app/src/main/java/pl/ppiwd/exerciseanalyst/persistence/dao/MeasurementsDao.java
@@ -5,16 +5,18 @@ import androidx.room.Transaction;
 
 import java.util.List;
 
+import io.reactivex.rxjava3.core.Single;
 import pl.ppiwd.exerciseanalyst.persistence.entities.AccelerometerMeasEntity;
 import pl.ppiwd.exerciseanalyst.persistence.entities.AltitudeMeasEntity;
 import pl.ppiwd.exerciseanalyst.persistence.entities.AmbientLightMeasEntity;
 import pl.ppiwd.exerciseanalyst.persistence.entities.GyroscopeMeasEntity;
 import pl.ppiwd.exerciseanalyst.persistence.entities.MagnetometerMeasEntity;
 import pl.ppiwd.exerciseanalyst.persistence.entities.PressureMeasEntity;
+import pl.ppiwd.exerciseanalyst.persistence.entities.SessionWithMeasurements;
 import pl.ppiwd.exerciseanalyst.persistence.entities.TemperatureMeasEntity;
 
 @Dao
-public abstract class MeasurementsDao implements AccelerometerDao, AltitudeDao, AmbientLightDao, GyroscopeDao, MagnetometerDao, PressureDao, TemperatureDao {
+public abstract class MeasurementsDao implements AccelerometerDao, AltitudeDao, AmbientLightDao, GyroscopeDao, MagnetometerDao, PressureDao, TemperatureDao, SessionDao {
 
     @Transaction
     public void insertMultipleMeasurements(
@@ -39,5 +41,9 @@ public abstract class MeasurementsDao implements AccelerometerDao, AltitudeDao, 
             insertPressureMeasurements(pressureMeasEntities);
         if (temperatureMeasEntities != null && temperatureMeasEntities.size() > 0)
             insertTemperatureMeasurements(temperatureMeasEntities);
+    }
+
+    public Single<SessionWithMeasurements> getMeasurementEntitiesForLastSession() {
+        return getLastSession();
     }
 }

--- a/app/src/main/java/pl/ppiwd/exerciseanalyst/persistence/dao/SessionDao.java
+++ b/app/src/main/java/pl/ppiwd/exerciseanalyst/persistence/dao/SessionDao.java
@@ -17,4 +17,8 @@ public interface SessionDao {
     @Transaction
     @Query("SELECT * FROM sessions WHERE id = :sessionId")
     public Single<SessionWithMeasurements> getSessionWithMeasurements(long sessionId);
+
+    @Transaction
+    @Query("SELECT * FROM sessions ORDER BY id DESC LIMIT 1")
+    public Single<SessionWithMeasurements> getLastSession();
 }


### PR DESCRIPTION
The following PR introduces changes that implement synchronizing measurements with the remote server.
As we don't have a public IP for the server, currently the request is sent to the root of [`SERVER_URL`](https://github.com/PPIWD/exercise-analyst-app/blob/11de9926b4c13945db43d323519c6eb5490c23c4/app/build.gradle#L15). 
You'll probably need to modify this locally, until we can hardcode this to some value.

Testing locally (Linux):
1. Run the following command to simulate a basic web server on host with port `8081`:
```[Shell]
$ while true; do echo -e "HTTP/1.1 200 OK\r\n$(date)\r\n\r\n<h1>hello world </h1>" | nc -q 10 -vl 8081; done
```
2. Modify the [`SERVER_URL`](https://github.com/PPIWD/exercise-analyst-app/blob/11de9926b4c13945db43d323519c6eb5490c23c4/app/build.gradle#L15) IP to match your host pc.
3. Start the measurement, move the watch thingy about.
4. Stop the measurement.
